### PR TITLE
Show consistent timestamps in widget

### DIFF
--- a/src/videojs-vjstranscribe-widget.js
+++ b/src/videojs-vjstranscribe-widget.js
@@ -42,13 +42,33 @@ export default class VjsTranscribeWidget {
     document.getElementById(this.widgetId).appendChild(this.$body);
   }
 
+  formatDuration(secondsFloat) {
+    // Convert float to integer seconds.
+    let totalSeconds = Math.floor(secondsFloat);
+
+    // Calculate hours, minutes, and seconds.
+    let hours = Math.floor(totalSeconds / 3600);
+    totalSeconds %= 3600; // Remaining seconds after extracting hours.
+    let minutes = Math.floor(totalSeconds / 60);
+    let seconds = totalSeconds % 60;
+
+    // Format minutes and seconds to always be two digits.
+    let formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+    let formattedSeconds = seconds < 10 ? `0${seconds}` : seconds;
+
+    // Construct duration string based on whether hours are present.
+    return hours > 0
+        ? `${hours}:${formattedMinutes}:${formattedSeconds}`
+        : `${formattedMinutes}:${formattedSeconds}`;
+  }
+
   createLine(cue) {
     let line = document.createElement('div');
     let timestamp = document.createElement('span');
     let text = document.createElement('span');
     line.setAttribute('data-begin', cue.startTime);
     line.classList.add('vjs-transcribe-cueline')
-    timestamp.textContent =  new Date(1000 * cue.startTime).toISOString().substr(11, 8).replace(/^[0:]+/, "");
+    timestamp.textContent = this.formatDuration(cue.startTime);
     timestamp.classList.add('vjs-transcribe-cuetimestamp');
     text.innerHTML = this.plugin.parseTags(cue.text);
     line.appendChild(timestamp);


### PR DESCRIPTION
This PR changes the way timestamps are displayed. This is my personal preference for how timestamps should be displayed, so feel free to close this if you don't agree.

I've opted for YouTube style timetamps, like so:
<img width="49" alt="Screenshot 2024-04-10 at 10 26 21" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/c669c57c-9e7c-440b-8416-e50cf88116fb">
<img width="53" alt="Screenshot 2024-04-10 at 10 26 12" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/08a0284d-f538-42ab-b76d-4eff422ae084">
<img width="64" alt="Screenshot 2024-04-10 at 10 26 09" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/f35710e9-e684-480d-80ab-1bef35cd1bd0">


### The screenshots below give a before and after:

## Before
<img width="756" alt="Screenshot 2024-04-10 at 10 18 15" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/50f8cc00-d4a8-470b-971e-1495493a1ec9">


## After
<img width="743" alt="Screenshot 2024-04-10 at 10 39 03" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/bbc6ece0-f727-49a6-be3f-fe4df6fd0aad">

<img width="765" alt="Screenshot 2024-04-10 at 10 40 21" src="https://github.com/7Ds7/videojs-vjstranscribe/assets/15688439/19111d84-8cea-4ae9-87f8-307385fdd1fa">
